### PR TITLE
ISSUE-3 & Issue-6: Provide a simple dev utility and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Astra
 On Demand Log Monitoring Service
+
+[Project Brief](https://docs.google.com/document/d/1a44aCd8sJOLXWNT2vTerRGuNAYSHsTLxdFJWxRCl2pA/edit#)
+[Project Tech Design](https://docs.google.com/document/d/1vjoh4NN57tht9tUDZSYe5K_T2J2nhUxp940qWcUisOw/edit#heading=h.2vb45ps60q20)
+[Github Project Board](https://github.com/users/karthikbic1/projects/1)
+
+
+# Development
+
+Run the following command to get started..
+
+```
+
+# Install Dependencies for the first time.
+$ bash script/dev init
+
+# Start the Astra App - defaults on port 3000
+$ bash script/dev up
+
+# Start the Astra App on a different port
+$ bash script/dev up 3001
+
+
+# To run unit tests
+$ bash script/dev test
+
+```
+
+
+
+

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [[ $1 == "init" ]]; then
+    echo "Init the dev setup..."
+    echo `pwd`
+    bash scripts/setup.sh
+    echo "Successfully installed dependencies.. "
+    echo "Start the app using - dev up"
+    
+elif [[ $1 == "up" ]]; then
+    echo "Building Astra app.."
+    go build
+    echo "Starting the Astra app.."
+    
+    port=$2
+    if [[ -z $port ]]; then
+        port=3000
+    fi
+    ./astra server --port=$port
+elif [[ $1 == "test" ]]; then
+    echo "Unit Testing Astra app.."
+    go test
+else
+    echo "Invalid choice. Select between dev init or dev up"
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+mkdir -p ~/.go
+echo "GOPATH=$HOME/.go" >> ~/.bashrc
+echo "export GOPATH" >> ~/.bashrc
+echo "PATH=\$PATH:\$GOPATH/bin # Add GOPATH/bin to PATH for scripting" >> ~/.bashrc
+source ~/.bashrc
+
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+    echo 'macOS'
+    brew update
+    brew install golang
+else
+    sudo snap install go --classic
+fi
+
+
+


### PR DESCRIPTION
Fixes #3 
Fixes #6

This PR adds a simple dev utility for user to bootstrap, start the server locally  and run tests.

Testing:

1. script/dev init
```
bash scripts/dev.sh init
Init the dev setup...
/home/karthik/workspace/Astra
Agent pid 224740
Identity added: /home/karthik/.ssh/id_ed25519 (karthikborkar+1@gmail.com)
[sudo] password for karthik: 
snap "go" is already installed, see 'snap help refresh'
Successfully installed dependencies.. 
Start the app using - dev up
karthik@karthik-Lenovo-IdeaP
```
2. bash script/dev,sh test
```
bash scripts/dev.sh test
Unit Testing Astra app..
?   	astra	[no test files]

```

3. bash script/dev.sh up

```
bash scripts/dev.sh up
Building Astra app..
Starting the Astra app..
2022/09/15 00:31:45 Listening on Port: 3000

```


